### PR TITLE
Colors and seo fix

### DIFF
--- a/src/gatsby-plugin-theme-ui/colors.js
+++ b/src/gatsby-plugin-theme-ui/colors.js
@@ -59,7 +59,7 @@ const colors = {
       muted: opaqueLightWhite,
       highlight: purple60,
       heading: white,
-      blogBg: "#333"
+      blogBg: "#2b2a32"
     },
   },
 }

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -36,7 +36,7 @@ const customStyles = merge(typography, {
       transitionDelay: ".1s",
       "&:hover": {
         transform: "translate(0, -4px)",
-        boxShadow: theme => `0 0 8px  ${theme.colors.hover}`,
+        boxShadow: theme => `0 2px 14px  ${theme.colors.hover}`,
       },
     },
     compact: {

--- a/static/fonts/fonts.css
+++ b/static/fonts/fonts.css
@@ -3,6 +3,7 @@
   font-family: 'Alegreya Sans';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/alegreya-sans-v21-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/alegreya-sans-v21-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -12,6 +13,7 @@
   font-family: 'Alegreya Sans';
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/alegreya-sans-v21-latin-italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/alegreya-sans-v21-latin-italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -21,6 +23,7 @@
   font-family: 'Alegreya Sans';
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: local(''),
        url('../fonts/alegreya-sans-v21-latin-500.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/alegreya-sans-v21-latin-500.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -30,6 +33,7 @@
   font-family: 'Alegreya Sans';
   font-style: italic;
   font-weight: 500;
+  font-display: swap;
   src: local(''),
        url('../fonts/alegreya-sans-v21-latin-500italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/alegreya-sans-v21-latin-500italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -39,6 +43,7 @@
   font-family: 'Alegreya Sans';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local(''),
        url('../fonts/alegreya-sans-v21-latin-700.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/alegreya-sans-v21-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -48,6 +53,7 @@
   font-family: 'Alegreya Sans';
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src: local(''),
        url('../fonts/alegreya-sans-v21-latin-700italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/alegreya-sans-v21-latin-700italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -58,6 +64,7 @@
   font-family: 'Kalam';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/kalam-v16-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/kalam-v16-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -3,4 +3,4 @@ Disallow: /404
 Disallow: /404-dev
 Disallow: /offline-plugin-app-shell-fallback
 
-Sitemap: https://secorto.com/sitemap/sitemap-index.xml
+Sitemap: https://www.secorto.com/sitemap/sitemap-index.xml


### PR DESCRIPTION
Cambiado el robots.txt que apuntaba a secorto.com sin www
El color de los post link no resaltaba tanto en el hover, se coloco una sombra mas grande para dar mas profundidad
Uso de font-display: swap para que no aparezcan textos vacios