### PR TITLE
Eliminado reach ui

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,13 @@
     // if you want to override the default language mapper inside, you can provide your own
     "mdx/language-mapper": {}
   },
+  "rules": {
+    "react/jsx-pascal-case": [
+      2, {
+        "allowNamespace": true
+      }
+    ]
+  },
   "ignorePatterns": [
     "**/public/*.js",
     "**/public/**/*.js",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.5",
     "@mdx-js/react": "^2.3.0",
-    "@reach/skip-nav": "^0.17.0",
-    "@reach/visually-hidden": "^0.17.0",
     "@theme-ui/css": "^0.15.5",
     "@theme-ui/mdx": "^0.15.5",
     "@theme-ui/prism": "^0.15.5",

--- a/src/components/ui/main.jsx
+++ b/src/components/ui/main.jsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { Container, jsx } from "theme-ui"
-import { SkipNavContent } from "@reach/skip-nav"
 
 const Main = ({ children, sidebarOpen, header, footer }) => (
   <div
@@ -13,11 +12,10 @@ const Main = ({ children, sidebarOpen, header, footer }) => (
   >
     {header}
     <Container>
-      <SkipNavContent />
-        <div sx={{pb: "5.3rem"}}>
-          {children}
-        </div>
-      </Container>
+      <div sx={{pb: "5.3rem"}} id="main-content">
+        {children}
+      </div>
+    </Container>
     {footer}
   </div>
 )

--- a/src/components/ui/visually-hidden.jsx
+++ b/src/components/ui/visually-hidden.jsx
@@ -1,0 +1,18 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+
+const VisuallyHidden = ({children, ...props}) => (
+  <div sx={{
+    clip: "rect(0 0 0 0)",
+    clipPath: "inset(50%)",
+    height: "1px",
+    overflow: "hidden",
+    position: "absolute",
+    whiteSpace: "nowrap",
+    width: "1px"
+  }} {...props}>
+    {children}
+  </div>
+)
+
+export default VisuallyHidden

--- a/src/containers/layout.jsx
+++ b/src/containers/layout.jsx
@@ -1,12 +1,9 @@
 import React from "react"
-import { SkipNavLink } from "@reach/skip-nav"
-import VisuallyHidden from "@reach/visually-hidden"
-import "@reach/skip-nav/styles.css"
-
 import Sidebar from "../components/Sidebar/sidebar"
 import BurgerButton from "../components/Sidebar/burger-button"
 import SidebarContext from "../context/SidebarContext"
 import Main from "../components/ui/main"
+import VisuallyHidden from "../components/ui/visually-hidden"
 
 const Layout = ({ children, header, footer }) => {
   return (
@@ -14,7 +11,7 @@ const Layout = ({ children, header, footer }) => {
       {sidebarOptions => (
         <div>
           <VisuallyHidden>
-            <SkipNavLink>Saltar al contenido</SkipNavLink>
+            <a href="#main-content">Saltar al contenido</a>
           </VisuallyHidden>
           <BurgerButton
             open={sidebarOptions.open}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {  Themed } from "@theme-ui/mdx"
 import Timeline from '../components/timeline'
 import timelineData from '../../content/timeline.yml'
 import PageTemplate from '../templates/page-template'
@@ -11,6 +12,7 @@ export const Head = () => <Seo title="Home" />
 const IndexPage = () => (
 <PageTemplate pageHeader={<Intro style={{background: '#1f1e24'}}/>}>
   <About/>
+  <Themed.h2>Mis logros</Themed.h2>
   <Timeline data={timelineData} />
 </PageTemplate>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,30 +2329,6 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@reach/skip-nav@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/skip-nav/-/skip-nav-0.17.0.tgz#225aaaf947f8750568ad5f4cc3646641fd335d56"
-  integrity sha512-wkkpQK3ffczzGHis6TaUvpOabuAL9n9Kh5vr4h56XPIJP3X77VcHUDk7MK3HbV1mTgamGxc9Hbd1sXKSWLu3yA==
-  dependencies:
-    "@reach/utils" "0.17.0"
-    tslib "^2.3.0"
-
-"@reach/utils@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
-  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
-  dependencies:
-    tiny-warning "^1.0.3"
-    tslib "^2.3.0"
-
-"@reach/visually-hidden@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz#033adba10b5ec419649da8d6bd8e46db06d4c3a1"
-  integrity sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==
-  dependencies:
-    prop-types "^15.7.2"
-    tslib "^2.3.0"
-
 "@rushstack/eslint-patch@^1.1.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
@@ -12491,11 +12467,6 @@ tiny-glob@^0.2.9:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
-tiny-warning@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 title-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
@@ -12611,7 +12582,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==


### PR DESCRIPTION
Closes #50 eliminado reach ui, link con nombre estatico, "main-content", y el componente visually-hidden se localiza en src/components/ui